### PR TITLE
[Feature]: Modal support function call 

### DIFF
--- a/packages/vue/components/modal/__tests__/__snapshots__/index.spec.ts.snap
+++ b/packages/vue/components/modal/__tests__/__snapshots__/index.spec.ts.snap
@@ -5,10 +5,10 @@ exports[`Modal should be support custom slots 1`] = `
   <!--teleport start-->
   <!--teleport end-->
   <transition-stub>
-    <div class="fect-teleport__overlay"></div>
+    <div class="fect-teleport__overlay" style="display: none;"></div>
   </transition-stub>
   <transition-stub>
-    <div class="fect-modal__root" role="popup">
+    <div class="fect-modal__root" role="popup" style="display: none;">
       <div role="dialog" tabindex="-1" class="fect-modal__wrapper" style="width: 400px;">
         <div class="fect-modal__title">Custom Title</div>
         <div class="fect-modal__content">
@@ -22,12 +22,12 @@ exports[`Modal should be support custom slots 1`] = `
 `;
 
 exports[`Modal should be support normal props 1`] = `
-<div class="container">
+<div class="container"><button id="btn">Button</button>
   <!--teleport start-->
   <!--teleport end-->
   <!---->
   <transition-stub>
-    <div class="fect-modal__root" role="popup">
+    <div class="fect-modal__root" role="popup" style="display: none;">
       <div role="dialog" tabindex="-1" class="fect-modal__wrapper" style="width: 500px;">
         <div class="fect-modal__title">
           <h2 class="title">Test Modal</h2>

--- a/packages/vue/components/modal/__tests__/function.spec.ts
+++ b/packages/vue/components/modal/__tests__/function.spec.ts
@@ -1,0 +1,37 @@
+import { createApp } from 'vue'
+import { later, trigger } from '../../../tests'
+import { Modal } from '../function-call'
+import ModalComponent from '../modal'
+
+describe('Modal', () => {
+  it('should be use work correctly', async () => {
+    const closeFn = jest.fn()
+    const confirmFn = jest.fn()
+    Modal({
+      title: 'test',
+      content: 'test message',
+      close: closeFn,
+      confirm: confirmFn
+    })
+    await later()
+    const btns = document.querySelectorAll('.fect-modal__button')
+    expect(document.querySelector('.fect-modal__wrapper')).toBeTruthy()
+    await trigger('click', btns[0])
+    expect(closeFn).toHaveBeenCalled()
+    expect(closeFn).toHaveBeenCalled()
+    Modal({
+      title: 'test',
+      content: 'test message',
+      close: closeFn,
+      confirm: confirmFn
+    })
+    await trigger('click', btns[1])
+    expect(confirmFn).toHaveBeenCalled()
+  })
+
+  it('should register component in to app', async () => {
+    const app = createApp(document.body)
+    app.use(Modal)
+    expect(app.component(ModalComponent.name)).toBeTruthy()
+  })
+})

--- a/packages/vue/components/modal/__tests__/index.spec.ts
+++ b/packages/vue/components/modal/__tests__/index.spec.ts
@@ -1,9 +1,9 @@
 import { mount } from '@vue/test-utils'
-import Modal from '../index'
+import Modal from '../modal'
 
 // see : https://github.com/vuejs/vue-test-utils-next/issues/183(test for teleport)
 
-// normal test . in feature will support instrcution
+// normal test . in future will support instrcution
 
 const Wrapper = {
   components: {
@@ -14,6 +14,7 @@ const Wrapper = {
   },
   template: `
   <div class="container">
+   <button id="btn" @click="show=true">Button</button>
     <fe-modal v-model:visible="show"
       :overlay="overlay"
       title="Test Modal"
@@ -73,8 +74,9 @@ describe('Modal', () => {
 
   it('should be close modal through props visible value is false', async () => {
     const wrapper = mount(Wrapper, { attachTo: document.body })
-    await wrapper.setData({ show: true })
+    const btn = wrapper.find('#btn')
     await wrapper.setData({ mounted: true })
+    await btn.trigger('click')
     expect(wrapper.find('.fect-modal__root').isVisible()).toBe(true)
     const el = wrapper.findAll('.fect-modal__button')
     await el[0].trigger('click')

--- a/packages/vue/components/modal/function-call.tsx
+++ b/packages/vue/components/modal/function-call.tsx
@@ -1,0 +1,29 @@
+import { App } from 'vue'
+import FeModal from './modal'
+import { withInstall, isBrowser } from '../utils'
+
+const Modal = (otpions: any) => {
+  if (!isBrowser()) return
+}
+
+Modal.defaultOptions = {
+  title: '',
+  width: '400px',
+  cancel: 'cancel',
+  done: 'done'
+}
+
+Modal.confirm = () => {}
+
+Modal.cancel = () => {}
+
+Modal.Component = withInstall(FeModal)
+
+Modal.install = (app: App) => {
+  app.use(Modal.Component)
+  app.config.globalProperties.$modal = Modal
+}
+
+export { Modal }
+
+Modal.confirm().cancel()

--- a/packages/vue/components/modal/function-call.tsx
+++ b/packages/vue/components/modal/function-call.tsx
@@ -51,7 +51,7 @@ Modal.defaultOptions = {
   width: '400px',
   cancel: 'cancel',
   done: 'done'
-}
+} as StaticModalOptions
 
 Modal.Component = withInstall(FeModal)
 

--- a/packages/vue/components/modal/index.ts
+++ b/packages/vue/components/modal/index.ts
@@ -1,6 +1,5 @@
-import { withInstall } from '../utils'
-import _Modal from './modal'
+import { Modal } from './function-call'
 
-export const Modal = withInstall(_Modal)
+export { Modal }
 
 export default Modal

--- a/packages/vue/components/modal/interface.ts
+++ b/packages/vue/components/modal/interface.ts
@@ -1,13 +1,13 @@
 import { Ref, ExtractPropTypes } from 'vue'
 import { props, staticModalProps } from './props'
 
-export type ModalProvide = {
-  props: ExtractPropTypes<typeof props>
+export type Action = 'confirm' | 'cancel'
+
+export type ModalContext = ExtractPropTypes<typeof props> & {
   selfVisible: Ref<boolean>
   setSelfVisible: (val: boolean) => void
+  setAction: (val: Action) => void
 }
-
-export const READONLY_MODAL_KEY = 'modalKey'
 
 export type StaticModalOptions = ExtractPropTypes<typeof staticModalProps> & {
   confirm: () => void

--- a/packages/vue/components/modal/interface.ts
+++ b/packages/vue/components/modal/interface.ts
@@ -1,7 +1,7 @@
 import { Ref, ExtractPropTypes } from 'vue'
 import { props, staticModalProps } from './props'
 
-export type Action = 'confirm' | 'cancel'
+export type Action = 'confirm' | 'cancel' | ''
 
 export type ModalContext = ExtractPropTypes<typeof props> & {
   selfVisible: Ref<boolean>
@@ -10,6 +10,7 @@ export type ModalContext = ExtractPropTypes<typeof props> & {
 }
 
 export type StaticModalOptions = ExtractPropTypes<typeof staticModalProps> & {
-  confirm: () => void
-  close: () => void
+  content?: string
+  confirm?: () => void
+  close?: () => void
 }

--- a/packages/vue/components/modal/interface.ts
+++ b/packages/vue/components/modal/interface.ts
@@ -9,7 +9,7 @@ export type ModalContext = ExtractPropTypes<typeof props> & {
   setAction: (val: Action) => void
 }
 
-export type StaticModalOptions = ExtractPropTypes<typeof staticModalProps> & {
+export type StaticModalOptions = Partial<ExtractPropTypes<typeof staticModalProps>> & {
   content?: string
   confirm?: () => void
   close?: () => void

--- a/packages/vue/components/modal/modal-action.tsx
+++ b/packages/vue/components/modal/modal-action.tsx
@@ -1,27 +1,27 @@
 import { defineComponent } from 'vue'
-import { useProvider } from '@fect-ui/vue-hooks'
 import Button from '../button/index'
-import { READONLY_MODAL_KEY, ModalProvide } from './type'
+import { useModalContext } from './modal-context'
+import type { Action } from './interface'
 
 const ModalAction = defineComponent({
   setup() {
-    const { context } = useProvider<ModalProvide>(READONLY_MODAL_KEY)
+    const { context } = useModalContext()
 
-    const closeClickHandler = (e: Event) => {
+    const closeClickHandler = (e: Event, action: Action) => {
       e.stopPropagation()
       e.preventDefault()
-      const { setSelfVisible } = context!
-      const { visible } = context?.props!
-      setSelfVisible(!visible)
+      const { selfVisible, setSelfVisible, setAction } = context!
+      setSelfVisible(!selfVisible)
+      setAction(action)
     }
 
     return () => (
       <footer class="fect-modal__action">
-        <Button class="fect-modal__button" onClick={closeClickHandler}>
-          {context?.props.cancel}
+        <Button class="fect-modal__button" onClick={(e) => closeClickHandler(e, 'cancel')}>
+          {context!.cancel}
         </Button>
-        <Button class="fect-modal__button" onClick={closeClickHandler}>
-          {context?.props.done}
+        <Button class="fect-modal__button" onClick={(e) => closeClickHandler(e, 'confirm')}>
+          {context!.done}
         </Button>
       </footer>
     )

--- a/packages/vue/components/modal/modal-context.ts
+++ b/packages/vue/components/modal/modal-context.ts
@@ -1,0 +1,8 @@
+import { createProvider, useProvider } from '@fect-ui/vue-hooks'
+import type { ModalContext } from './interface'
+
+export const READONLY_MODAL_KEY = Symbol('modalKey')
+
+export const createModalContext = () => createProvider(READONLY_MODAL_KEY)
+
+export const useModalContext = () => useProvider<ModalContext>(READONLY_MODAL_KEY)

--- a/packages/vue/components/modal/modal-title.tsx
+++ b/packages/vue/components/modal/modal-title.tsx
@@ -1,13 +1,12 @@
 import { defineComponent } from 'vue'
-import { useProvider } from '@fect-ui/vue-hooks'
-import { READONLY_MODAL_KEY, ModalProvide } from './type'
+import { useModalContext } from './modal-context'
 
 const ModalTitle = defineComponent({
   setup() {
-    const { context } = useProvider<ModalProvide>(READONLY_MODAL_KEY)
+    const { context } = useModalContext()
     return () => (
       <div class="fect-modal__title">
-        <h2 class="title">{context?.props.title}</h2>
+        <h2 class="title">{context?.title}</h2>
       </div>
     )
   }

--- a/packages/vue/components/modal/modal-wrapper.tsx
+++ b/packages/vue/components/modal/modal-wrapper.tsx
@@ -18,7 +18,7 @@ const ModalWrapper = defineComponent({
     }
 
     const renderWrapper = () => {
-      const { width } = context!
+      const { width, selfVisible } = context!
       return (
         <div role="dialog" tabindex={-1} class="fect-modal__wrapper" style={{ width }}>
           {renderTitle()}

--- a/packages/vue/components/modal/modal-wrapper.tsx
+++ b/packages/vue/components/modal/modal-wrapper.tsx
@@ -18,7 +18,7 @@ const ModalWrapper = defineComponent({
     }
 
     const renderWrapper = () => {
-      const { width, selfVisible } = context!
+      const { width } = context!
       return (
         <div role="dialog" tabindex={-1} class="fect-modal__wrapper" style={{ width }}>
           {renderTitle()}

--- a/packages/vue/components/modal/modal-wrapper.tsx
+++ b/packages/vue/components/modal/modal-wrapper.tsx
@@ -1,13 +1,11 @@
 import { defineComponent } from 'vue'
-import { useProvider } from '@fect-ui/vue-hooks'
 import ModalAction from './modal-action'
 import ModalTitle from './modal-title'
-
-import { READONLY_MODAL_KEY, ModalProvide } from './type'
+import { useModalContext } from './modal-context'
 
 const ModalWrapper = defineComponent({
   setup(props, { slots }) {
-    const { context } = useProvider<ModalProvide>(READONLY_MODAL_KEY)
+    const { context } = useModalContext()
 
     const renderTitle = () => {
       const titleSlot = slots['title']
@@ -20,7 +18,7 @@ const ModalWrapper = defineComponent({
     }
 
     const renderWrapper = () => {
-      const { width } = context?.props!
+      const { width } = context!
       return (
         <div role="dialog" tabindex={-1} class="fect-modal__wrapper" style={{ width }}>
           {renderTitle()}

--- a/packages/vue/components/modal/modal.tsx
+++ b/packages/vue/components/modal/modal.tsx
@@ -18,9 +18,9 @@ export default defineComponent({
   setup(props, { attrs, slots, emit }) {
     const modalRef = ref<ComponentInstance>()
 
-    const [selfVisible, setSelfVisible] = useState<boolean>(props.visible)
+    const [selfVisible, setSelfVisible] = useState<boolean>(false)
 
-    const [action, setAction] = useState<Action>('cancel')
+    const [action, setAction] = useState<Action>('')
 
     const { provider } = createModalContext()
 
@@ -28,7 +28,10 @@ export default defineComponent({
 
     watch(
       () => props.visible,
-      (cur) => setSelfVisible(cur)
+      (cur) => {
+        setSelfVisible(cur)
+        setAction('')
+      }
     )
     watch(selfVisible, (cur) => emit('update:visible', cur))
 
@@ -41,6 +44,7 @@ export default defineComponent({
       const element = modalRef.value!.$el
       if (element && element.contains(e.target as Node)) return
       setSelfVisible(!selfVisible.value)
+      setAction('cancel')
     }
 
     return () => (
@@ -50,7 +54,7 @@ export default defineComponent({
         scroll={selfVisible.value}
         popupClass="fect-modal__root"
         transition="modal-fade"
-        v-model={[selfVisible.value, 'show']}
+        show={selfVisible.value}
         onPopupClick={popupClickHandler}
       >
         <ModalWrapper {...attrs} v-slots={slots} ref={modalRef} />

--- a/packages/vue/components/modal/props.ts
+++ b/packages/vue/components/modal/props.ts
@@ -29,4 +29,4 @@ export const props = {
   }
 }
 
-export const staticModalProps = omit(props, 'teleport', 'overlay')
+export const staticModalProps = omit(props, 'teleport', 'overlay', 'visible')

--- a/packages/vue/components/modal/props.ts
+++ b/packages/vue/components/modal/props.ts
@@ -1,0 +1,32 @@
+import { PropType } from 'vue'
+import { omit } from '../utils'
+
+export const props = {
+  visible: Boolean,
+  title: {
+    tupe: String,
+    default: ''
+  },
+  width: {
+    type: String,
+    default: '400px'
+  },
+  cancel: {
+    type: String,
+    default: 'cancel'
+  },
+  done: {
+    type: String,
+    default: 'done'
+  },
+  teleport: {
+    type: String as PropType<keyof HTMLElementTagNameMap>,
+    default: 'body'
+  },
+  overlay: {
+    type: Boolean,
+    default: true
+  }
+}
+
+export const staticModalProps = omit(props, 'teleport', 'overlay')

--- a/packages/vue/components/modal/type.ts
+++ b/packages/vue/components/modal/type.ts
@@ -1,19 +1,15 @@
-import { Ref } from 'vue'
-
-interface Props {
-  visible: boolean
-  title: string
-  width: string
-  cancel: string
-  done: string
-  teleport: keyof HTMLElementTagNameMap
-  overlay: boolean
-}
+import { Ref, ExtractPropTypes } from 'vue'
+import { props, staticModalProps } from './props'
 
 export type ModalProvide = {
-  props: Props
+  props: ExtractPropTypes<typeof props>
   selfVisible: Ref<boolean>
   setSelfVisible: (val: boolean) => void
 }
 
 export const READONLY_MODAL_KEY = 'modalKey'
+
+export type StaticModalOptions = ExtractPropTypes<typeof staticModalProps> & {
+  confirm: () => void
+  close: () => void
+}

--- a/packages/vue/components/utils/composables/use-portal.ts
+++ b/packages/vue/components/utils/composables/use-portal.ts
@@ -14,7 +14,10 @@ const createPortal = (children: Component, container?: ElementRef) => {
   const elSnapshot = unref(container) || document.createElement('div')
   const app = createApp(children)
   document.body.appendChild(elSnapshot)
-  app.mount(elSnapshot)
+  const instance = app.mount(elSnapshot)
+  return {
+    instance
+  }
 }
 
 export { createNode, createPortal }

--- a/packages/vue/jest.config.js
+++ b/packages/vue/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
     '!components/index.ts',
     '!components/**/type.ts',
     '!components/**/style.ts',
+    '!components/**/interface.ts',
     '!components/back-top/**'
   ],
   collectCoverage: true,

--- a/packages/website/docs/en-us/components/modal.md
+++ b/packages/website/docs/en-us/components/modal.md
@@ -22,16 +22,47 @@ modal/custom.vue
 
 :::
 
+### Functional
+
+`Modal` is a function，the corresponding modal box will pop up directly on the page after calling.
+
+:::playground
+
+modal/function.vue
+
+:::
+
 ### Modal Props
 
 | Attribue            | Description         | Type          | Accepted values  | Default  |
 | ------------------- | ------------------- | ------------- | ---------------- | -------- |
 | **v-model:visible** | visible or hidden   | `boolean`     | `'true','false'` | `false`  |
 | **title**           | modal title         | `string`      | `-`              | `-`      |
-| **width**           | modal width         | `string`      | `-`              | `420px`  |
+| **width**           | modal width         | `string`      | `-`              | `400px`  |
 | **cancel**          | cancel button text  | `string`      | `-`              | `cancel` |
 | **done**            | confrim button text | `string`      | `-`              | `done`   |
 | **teleport**        | modal mounted node  | `HTMLElement` | `-`              | `body`   |
+
+### Modal Options
+
+Only work with function call.
+
+| Attribue    | Description         | Type       | Accepted values | Default  |
+| ----------- | ------------------- | ---------- | --------------- | -------- |
+| **title**   | modal title         | `string`   | `-`             | `-`      |
+| **width**   | modal width         | `string`   | `-`             | `400px`  |
+| **cancel**  | cancel button text  | `string`   | `-`             | `cancel` |
+| **done**    | confrim button text | `string`   | `-`             | `done`   |
+| **content** | modal text content  | `string`   | `-`             | `-`      |
+| **close**   | modal cancel event  | `()=>void` | `-`             | `-`      |
+| **confirm** | modal confirm event | `()=>void` | `-`             | `-`      |
+
+### Modal Events
+
+| Event       | Description         | Type       |
+| ----------- | ------------------- | ---------- |
+| **cancel**  | modal cancel event  | `()=>void` |
+| **confirm** | modal confirm event | `()=>void` |
 
 ### Modal Slots
 

--- a/packages/website/docs/example/modal/default.vue
+++ b/packages/website/docs/example/modal/default.vue
@@ -1,29 +1,39 @@
 <template>
   <div>
     <fe-button @click="handlerClick">Button</fe-button>
-    <fe-modal title="箭头函数" v-model:visible="show" cancel="放弃使用" done="明白了" @confirm="confirmHandler">
+    <fe-modal title="箭头函数" v-model:visible="show" cancel="放弃使用" done="明白了">
       <p>众所周知箭头函数没有自己的<fe-code>this</fe-code>因此,它依赖于外部指向。</p>
     </fe-modal>
+    <fe-spacer />
   </div>
 </template>
 
 <script>
-import { ref } from 'vue'
+import { ref, getCurrentInstance } from 'vue'
 
 export default {
   name: 'ex-modal-default',
 
   setup() {
     const show = ref(false)
+    const { proxy } = getCurrentInstance()
     const handlerClick = () => (show.value = true)
 
-    const confirmHandler = () => {
-      console.log('z')
+    const click = () => {
+      proxy.$modal({
+        title: 'Arrow Function',
+        content:
+          'As we all know, the arrow function does not have its own this. Therefore, it depends on the external direction.',
+        cancel: 'Cancel',
+        done: 'Confirm',
+        confirm: () => console.log('')
+      })
     }
+
     return {
       show,
       handlerClick,
-      confirmHandler
+      click
     }
   }
 }

--- a/packages/website/docs/example/modal/default.vue
+++ b/packages/website/docs/example/modal/default.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <fe-button @click="handlerClick">Button</fe-button>
-    <fe-modal title="箭头函数" v-model:visible="show" cancel="放弃使用" done="明白了">
+    <fe-modal title="箭头函数" v-model:visible="show" cancel="放弃使用" done="明白了" @confirm="confirmHandler">
       <p>众所周知箭头函数没有自己的<fe-code>this</fe-code>因此,它依赖于外部指向。</p>
     </fe-modal>
   </div>
@@ -16,9 +16,14 @@ export default {
   setup() {
     const show = ref(false)
     const handlerClick = () => (show.value = true)
+
+    const confirmHandler = () => {
+      console.log('z')
+    }
     return {
       show,
-      handlerClick
+      handlerClick,
+      confirmHandler
     }
   }
 }

--- a/packages/website/docs/example/modal/function.vue
+++ b/packages/website/docs/example/modal/function.vue
@@ -1,0 +1,31 @@
+<template>
+  <div>
+    <fe-button @click="clickHandler" size="mini" auto>Button</fe-button>
+  </div>
+</template>
+
+<script>
+import { getCurrentInstance } from 'vue'
+
+export default {
+  name: 'ex-modal-function',
+
+  setup() {
+    const { proxy } = getCurrentInstance()
+
+    const clickHandler = () => {
+      proxy.$modal({
+        title: 'Arrow Function',
+        content:
+          'As we all know, the arrow function does not have its own this. Therefore, it depends on the external direction.',
+        cancel: 'Cancel',
+        done: 'Confirm'
+      })
+    }
+
+    return {
+      clickHandler
+    }
+  }
+}
+</script>

--- a/packages/website/docs/zh-cn/components/modal.md
+++ b/packages/website/docs/zh-cn/components/modal.md
@@ -22,7 +22,15 @@ modal/custom.vue
 
 :::
 
-<!-- <playground title="指令" name="ex-modal-direct" desc="使用指令唤醒modal" /> -->
+### 函数调用
+
+`Modal`是一个函数，调用后会直接在页面中弹出相应的模态框
+
+:::playground
+
+modal/function.vue
+
+:::
 
 ### Modal Props
 
@@ -30,12 +38,31 @@ modal/custom.vue
 | ------------------- | -------------------- | ------------- | ---------------- | -------- |
 | **v-model:visible** | 显示与隐藏           | `boolean`     | `'true','false'` | `false`  |
 | **title**           | 标题                 | `string`      | `-`              | `-`      |
-| **width**           | 对话框宽度           | `string`      | `-`              | `420px`  |
+| **width**           | 对话框宽度           | `string`      | `-`              | `400px`  |
 | **cancel**          | 取消按钮的文字       | `string`      | `-`              | `cancel` |
 | **done**            | 确定按钮的文字       | `string`      | `-`              | `done`   |
 | **teleport**        | 指定对话框挂载的节点 | `HTMLElement` | `-`              | `body`   |
 
-### Modal customSlots
+### Modal Options
+
+| 属性        | 描述             | 类型       | 可选值 | 默认     |
+| ----------- | ---------------- | ---------- | ------ | -------- |
+| **title**   | 标题             | `string`   | `-`    | `-`      |
+| **width**   | 对话框宽度       | `string`   | `-`    | `400px`  |
+| **cancel**  | 取消按钮的文字   | `string`   | `-`    | `cancel` |
+| **done**    | 确定按钮的文字   | `string`   | `-`    | `done`   |
+| **content** | 模态框文本内容   | `string`   | `-`    | `-`      |
+| **close**   | 模态框的取消事件 | `()=>void` | `-`    | `-`      |
+| **confirm** | 模态框的确认事件 | `()=>void` | `-`    | `-`      |
+
+### Modal Events
+
+| 事件        | 描述             | 类型       |
+| ----------- | ---------------- | ---------- |
+| **cancel**  | 模态框的取消事件 | `()=>void` |
+| **confirm** | 模态框的确认事件 | `()=>void` |
+
+### Modal Slots
 
 <fe-card>
   Modal组件默认提供了<fe-code>title,action</fe-code>插槽。启用时<fe-code>title,cancel,done</fe-code>


### PR DESCRIPTION
## Checklist

---

- [x] Fix linting errors
- [x] Tests have been added / updated (or snapshots)
- [x] Add new events `cancel` and `confirm` 

## Change information

---

- Support modal component function call . 
- And register `$modal` in vue global.

## Usage:

```js

import { getCurrentInstance } from 'vue'

import { Modal } from '@fect-ui/vue'

const clickHandler = () => Modal({ title: 'test' })

// or

 const { proxy } = getCurrentInstance()

const clickHandler = () => {
      proxy.$modal({
        title: 'Arrow Function',
        content:
          'As we all know, the arrow function does not have its own this. ',
        cancel: 'Cancel',
        done: 'Confirm'
      })
    }

```

- more details see the document.


