### PR TITLE
fix(input-icon): modify the space based on position

### DIFF
--- a/packages/vue/components/input/__tests__/__snapshots__/index.spec.ts.snap
+++ b/packages/vue/components/input/__tests__/__snapshots__/index.spec.ts.snap
@@ -103,7 +103,7 @@ exports[`Input should be support icon 1`] = `
     <div class="fect-input__container">
       <!---->
       <div class="fect-input__wrapper  ">
-        <div class="fect-input__icon"><svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" shape-rendering="geometricPrecision" viewBox="0 0 24 24" height="24" width="24" style="color: currentColor;">
+        <div class="fect-input__icon fect-input__icon-prefix"><svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" shape-rendering="geometricPrecision" viewBox="0 0 24 24" height="24" width="24" style="color: currentColor;">
             <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 00-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0020 4.77 5.07 5.07 0 0019.91 1S18.73.65 16 2.48a13.38 13.38 0 00-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 005 4.77a5.44 5.44 0 00-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 009 18.13V22"></path>
           </svg></div><input type="text" class="" style="font-size: 14px;">
         <!---->
@@ -142,7 +142,7 @@ exports[`Input should support clearable and password icon 1`] = `
           <path d="M18 6L6 18"></path>
           <path d="M6 6l12 12"></path>
         </svg></div>
-      <div class="fect-input__icon" style="cursor: pointer; pointer-events: auto;"><svg viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none" shape-rendering="geometricPrecision" style="color: currentColor;">
+      <div class="fect-input__icon fect-input__icon-suffix" style="cursor: pointer; pointer-events: auto;"><svg viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none" shape-rendering="geometricPrecision" style="color: currentColor;">
           <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
           <circle cx="12" cy="12" r="3"></circle>
         </svg></div>

--- a/packages/vue/components/input/icon-content.tsx
+++ b/packages/vue/components/input/icon-content.tsx
@@ -15,7 +15,7 @@ const IconContent = defineComponent({
     })
 
     return () => (
-      <div class="fect-input__icon" style={baseStyle.value} onClick={(e) => emit('click', e)}>
+      <div class="fect-input__icon fect-input__icon-suffix" style={baseStyle.value} onClick={(e) => emit('click', e)}>
         {slots.default?.()}
       </div>
     )

--- a/packages/vue/components/input/index.less
+++ b/packages/vue/components/input/index.less
@@ -98,10 +98,17 @@
     padding: calc(var(--heightRatio) * var(--fay-gap) * 0.3);
     line-height: 1;
     position: relative;
+    &-prefix {
+      padding-right: 0;
+    }
+    &-suffix {
+      padding-left: 0;
+    }
   }
 
   &__clear-icon {
     padding: 0 var(--fay-gap-half);
+    padding-left: 0;
     margin: 0;
     display: inline-flex;
     align-items: center;

--- a/packages/vue/components/input/input.tsx
+++ b/packages/vue/components/input/input.tsx
@@ -182,7 +182,7 @@ export default defineComponent({
     })
 
     const renderIcon = () => {
-      return <div class="fect-input__icon">{slots.icon?.()}</div>
+      return <div class="fect-input__icon fect-input__icon-prefix">{slots.icon?.()}</div>
     }
 
     return () => (


### PR DESCRIPTION
## Checklist

---

- [x] Modify the space based on position of icon
- [x] Add `prefix` and `suffix` to the __icon class, also `padding-left:0` to the __clear-icon
- [x] Tests have been added / updated (or snapshots)

## Change information

---
``` css
 &__icon {
    box-sizing: content-box;
    display: flex;
    align-items: center;
    vertical-align: middle;
    margin: 0;
    width: calc(var(--heightRatio) * 10.66px);
    padding: calc(var(--heightRatio) * var(--fay-gap) * 0.3);
    line-height: 1;
    position: relative;
    &-prefix {
      padding-right: 0;
    }
    &-suffix {
      padding-left: 0;
    }
  }

  &__clear-icon {
    padding: 0 var(--fay-gap-half);
    padding-left: 0;
```
### Before
![image](https://user-images.githubusercontent.com/35440329/146487296-37b48131-5c12-426e-9b33-57821acbfaa1.png)
![image](https://user-images.githubusercontent.com/35440329/146487388-6218f98e-02d0-497d-bdb4-a30ade10da86.png)

### After
![image](https://user-images.githubusercontent.com/35440329/146487426-c1767c39-dd0d-4eb9-aa82-faa9f59f50d5.png)
![image](https://user-images.githubusercontent.com/35440329/146487449-498a1b81-54aa-4686-bff3-e38832de6f14.png)
