### PR TITLE
feat(composables): match system dark mode when first open

### DIFF
--- a/packages/vue/components/utils/composables/use-theme.ts
+++ b/packages/vue/components/utils/composables/use-theme.ts
@@ -18,7 +18,11 @@ export const useTheme = () => {
 
   onMounted(() => {
     if (typeof window === 'undefined' || !window.localStorage) return
-    const theme = (localStorage.getItem('theme') as Theme) || 'light-theme'
+
+    const isDarkMode =
+      matchMedia('(prefers-color-scheme)').media !== 'not all' && matchMedia('(prefers-color-scheme: dark)').matches
+
+    const theme = (localStorage.getItem('theme') as Theme) || (isDarkMode ? 'dark-theme' : 'light-theme')
     setTheme(theme)
   })
 


### PR DESCRIPTION
affects: @fect-ui/vue

## Checklist

---

- [x] 清空localStorage并打开系统深色模式，首次进入页面显示深色主题；系统浅色模式，页面显示浅色主题

## Change information

---

增加了对于系统深色模式的检测
