### PR TITLE
[Fix]: remove switch component hasEmpty logic

### DIFF
--- a/packages/vue/src/switch/__tests__/index.spec.ts
+++ b/packages/vue/src/switch/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils'
-import Switch from '..'
+import { Switch, SwitchEvent } from '..'
 
 const Wrapper = {
   components: {
@@ -39,5 +39,21 @@ describe('Switch', () => {
     await el.trigger('click')
     expect(wrapper.emitted('update:modelValue')).toBeFalsy()
     expect(wrapper.html()).toMatchSnapshot()
+  })
+  it('switch should support control data flow by manual', async () => {
+    let state: unknown
+    const switchChangeHandler = (e: SwitchEvent) => {
+      state = e.target.checked
+    }
+    const wrapper = mount(Switch, {
+      props: {
+        value: true,
+        onChange: switchChangeHandler
+      }
+    })
+    expect(wrapper.find('.fect-switch--checked').exists()).toBe(true)
+    const el = wrapper.find('.fect-switch')
+    await el.trigger('click')
+    expect(state).toBe(false)
   })
 })

--- a/packages/vue/src/switch/index.ts
+++ b/packages/vue/src/switch/index.ts
@@ -5,4 +5,4 @@ export const Switch = withInstall(_Switch)
 
 export default Switch
 
-export type { SwitchEvent } from './switch'
+export type { SwitchEvent } from './interface'

--- a/packages/vue/src/switch/interface.ts
+++ b/packages/vue/src/switch/interface.ts
@@ -1,0 +1,10 @@
+export interface SwitchEventTarget {
+  checked: unknown
+}
+
+export interface SwitchEvent {
+  target: SwitchEventTarget
+  stopPropagation: () => void
+  preventDefault: () => void
+  nativeEvent: Event
+}

--- a/packages/vue/src/utils/format/string.ts
+++ b/packages/vue/src/utils/format/string.ts
@@ -3,13 +3,6 @@ const KEBACASE = /[A-Z]+(?![a-z])|[A-Z]/g
 
 export const camelize = (str: string): string => str.replace(CAMELIZERE, (_, key) => key.toUpperCase())
 
-export const hasEmpty = (str: any): boolean => {
-  if (typeof str === 'undefined') return true
-  if (isNaN(str)) return true
-  if (str === null) return true
-  return false
-}
-
 export const getId = () => Math.random().toString(32).slice(2, 10)
 
 export const kebabCase = (str: string): string => str.replace(KEBACASE, (_, ofs) => (ofs ? '-' : '') + _.toLowerCase())


### PR DESCRIPTION
## Checklist

---

- [x] Fix linting errors
- [x] Tests have been added / updated (or snapshots)

## Change information

---

- Remove `hasEmpty` logic, because user specify a custom value. it will cause the internal logic confusion. 
- Remove useless `computed` logic.
- Change manual control data flow logic. In past, we will auto set internal value by `watchEffect`,But it unreasonable, So change it, Now the internal logic will be:

```js

 watchEffect(() => {
      if (props.value) {
        setCurrentValue(props.value)
      }
 })

```

- Change internal value variable name from `value` => `currentValue`.

