### PR TITLE
fix(vue-hooks): fix use-state type

### DIFF
--- a/packages/vue-hooks/src/use-state/use-state.ts
+++ b/packages/vue-hooks/src/use-state/use-state.ts
@@ -1,5 +1,5 @@
 import { ref, readonly } from 'vue'
-import type { UnwrapRef, Ref } from 'vue'
+import type { UnwrapRef, Ref, DeepReadonly } from 'vue'
 
 export type SetStateAction<S> = S | ((prevState: S) => S)
 
@@ -11,7 +11,7 @@ const useState = <T>(initial?: T) => {
     const draft = typeof next === 'function' ? (next as (prevState: T) => T)(state.value as T) : next
     state.value = draft as UnwrapRef<T>
   }
-  return [readonly(state), dispatch] as [Ref<T>, Dispatch<T>]
+  return [readonly(state), dispatch] as [DeepReadonly<Ref<T>>, Dispatch<T>]
 }
 
 export { useState }


### PR DESCRIPTION
## Checklist

---

- [x] Fix linting errors

## Change information

---

- change return type `Ref<T>` to `DeepReadonly<Ref<T>>`
